### PR TITLE
✨[Feat]#14 - 모집글 작성 페이지 UI 구현

### DIFF
--- a/Muje/Muje/Common/Enum/UploadPost/UploadPostStatus.swift
+++ b/Muje/Muje/Common/Enum/UploadPost/UploadPostStatus.swift
@@ -1,0 +1,36 @@
+//
+//  PostStatus.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import Foundation
+
+enum UploadPostStatus: CaseIterable {
+    case input
+    case interview
+    case info
+    
+    var postingLevel: String {
+        switch self {
+        case .input:
+            return "1"
+        case .interview:
+            return "2"
+        case .info:
+            return "3"
+        }
+    }
+    
+    var postingTitle: String {
+        switch self {
+        case .input:
+            return "모임 상세내용을 입력해주세요"
+        case .interview:
+            return "면접을 진행하시나요?"
+        case .info:
+            return "지원자로부터 \n수집할 정보를 선택해주세요"
+        }
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/Component/ActionButton.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/ActionButton.swift
@@ -1,0 +1,24 @@
+//
+//  ActionButton.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+
+struct ActionButton: View {
+    var title: String
+    var condition: Bool
+    
+    var body: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(condition ? Color.gray.opacity(0.2) : Color.black)
+            .frame(height: 56)
+            .overlay(content: {
+                Text(title)
+                    .foregroundStyle(condition ? Color.secondary : Color.white)
+                    .bold()
+            })
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/Component/CustomInput.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/CustomInput.swift
@@ -1,0 +1,40 @@
+//
+//  CustomInput.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+
+struct CustomInput: View {
+    var title: String
+    var tempTitle: String
+    var textValue: Binding<String>
+    var subTitle: String?
+    let maxLength: Int
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            if let sub = subTitle {
+                HStack(spacing: 4) {
+                    Text(title)
+                    Text(sub)
+                        .font(.caption)
+                        .foregroundStyle(Color.gray)
+                }
+            } else {
+                Text(title)
+            }
+            TextField(tempTitle, text: textValue, axis: .vertical)
+                .maxLength(text: textValue, maxLength)
+                .bold()
+                .padding(18)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.clear)
+                        .strokeBorder(Color.gray.opacity(0.2), lineWidth: 1)
+                )
+        }
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/Component/MaxLengthModifier.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/MaxLengthModifier.swift
@@ -1,0 +1,22 @@
+//
+//  MaxLengthModifier.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+
+struct MaxLengthModifier: ViewModifier {
+    @Binding var text: String
+    let maxLength: Int
+    
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: text) { old, new in
+                if new.count > maxLength {
+                    text = old
+                }
+            }
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/Component/PostDatePicker.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/PostDatePicker.swift
@@ -1,0 +1,47 @@
+//
+//  PostDatePicker.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+
+struct PostDatePicker: View {
+    let title: String
+    let content: String
+    let function: () -> Void
+    
+    @State var isSelected: Bool = false
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(title)
+            
+            Button(action: {
+                function()
+            }, label: {
+                HStack(spacing: 6) {
+                    Text(content)
+                        .foregroundStyle(isSelected ? Color.black : Color.gray)
+                    Spacer()
+                    Image(systemName: "calendar")
+                }
+                .foregroundStyle(Color.gray)
+                .padding(18)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.white)
+                        .stroke(Color.gray, style: StrokeStyle(lineWidth: 1))
+                )
+                .onChange(of: content, { old, new in
+                    isSelected = true
+                })
+            })
+        }
+    }
+}
+
+#Preview {
+    PostDatePicker(title: "마감일 선택", content: "asdfs", function: {print("S")}, isSelected: true)
+}

--- a/Muje/Muje/Modules/UploadPost/Component/StatusView.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/StatusView.swift
@@ -1,0 +1,45 @@
+//
+//  StatusVIew.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+
+struct StatusView: View {
+    @Binding var uploadPostViewModel: UploadPostViewModel
+    
+    var body: some View {
+        VStack(alignment: .leading ,spacing: 12) {
+            HStack(spacing: 10) {
+                ForEach(UploadPostStatus.allCases, id: \.self) { status in
+                    if status == uploadPostViewModel.currentStatus {
+                        Circle()
+                            .fill(Color.blue)
+                            .frame(width: 23)
+                            .overlay(content: {
+                                Text(status.postingLevel)
+                                    .bold()
+                                    .foregroundStyle(Color.white)
+                            })
+                    } else {
+                        Circle()
+                            .fill(Color.gray.opacity(0.2))
+                            .frame(width: 10)
+                    }
+                }
+            }
+            
+            Text(uploadPostViewModel.currentStatus.postingTitle)
+                .foregroundStyle(Color.black)
+                .font(.title2)
+                .bold()
+        }
+        .padding(.bottom, uploadPostViewModel.currentStatus == .interview ? 28 : 42)
+    }
+}
+
+#Preview {
+    StatusView(uploadPostViewModel: .constant(.init()))
+}

--- a/Muje/Muje/Modules/UploadPost/Component/Toast.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/Toast.swift
@@ -1,0 +1,31 @@
+//
+//  Toast.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+
+struct Toast: View {
+    @Binding var isShown: Bool
+    var message: String = "message"
+    
+    var body: some View {
+        VStack {
+            if isShown {
+                HStack(spacing: 16) {
+                    Text(message)
+                        .foregroundStyle(Color.white)
+                }
+                .hvPadding(16, 10)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color.black.opacity(0.6)))
+                .transition(.move(edge: .bottom))
+            }
+        }
+    }
+}
+
+#Preview {
+    Toast(isShown: .constant(true))
+}

--- a/Muje/Muje/Modules/UploadPost/ViewModels/PostInfoViewModel.swift
+++ b/Muje/Muje/Modules/UploadPost/ViewModels/PostInfoViewModel.swift
@@ -1,0 +1,59 @@
+//
+//  PostInfoViewModel.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+@Observable
+final class PostInfoViewModel {
+    var title: String = ""
+    var organization: String = ""
+    var content: String = ""
+    var startDate = Date()
+    var endDate: Date = Date()
+    var endDateString: String = "마감일 선택"
+    var isPicker: Bool = false
+    var selectedItems: [PhotosPickerItem] = []
+    var selectedImagesData: [Data] = []
+    var showToast: Bool = false
+    
+    var dateRange: ClosedRange<Date> {
+        let min = Date()
+        let max = Date().addingTimeInterval(60 * 60 * 24 * 365) //시작날짜 이후로 1년(365일 후)
+        return min...max
+    }
+    
+    
+    func nextCheck() -> Bool {
+        return (title.count < 5 || organization.count < 2 || content.count < 20 || startDate >= endDate)
+    }
+    
+    func removeImage(at index: Int) {
+        guard selectedImagesData.indices.contains(index), selectedItems.indices.contains(index) else {
+            return
+        }
+        
+        selectedImagesData.remove(at: index)
+        selectedItems.remove(at: index)
+    }
+    
+    func connectDate() {
+        isPicker = false
+        endDateString = endDate.dateString
+    }
+    
+    func debug() {
+        print("제목: \(title)")
+        print("단체명: \(organization)")
+        print("내용: \(content)")
+        print("모집날짜: \(startDate.shortDateString)")
+        print("종료 날짜: \(endDate.shortDateString)")
+        print("종료 날짜 형식: \(endDateString)")
+        print("시트: \(isPicker)")
+        print("선택된 이미지 수: \(selectedItems.count)")
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/ViewModels/PostInterviewViewModel.swift
+++ b/Muje/Muje/Modules/UploadPost/ViewModels/PostInterviewViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  PostInterviewViewModel.swift
+//  Muje
+//
+//  Created by Air on 8/25/25.
+//
+
+import Foundation

--- a/Muje/Muje/Modules/UploadPost/ViewModels/UploadPostViewModel.swift
+++ b/Muje/Muje/Modules/UploadPost/ViewModels/UploadPostViewModel.swift
@@ -1,0 +1,15 @@
+//
+//  UploadPostViewModel.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+
+@Observable
+final class UploadPostViewModel {
+    var currentStatus: UploadPostStatus = .input
+    var isQuit: Bool = false
+    var alertContents: [String] = ["지금까지 작성한 내용이 저장되지 않습니다\n나가시겠어요?", "중단하고 나가기", "계속 작성하기"]
+}

--- a/Muje/Muje/Modules/UploadPost/Views/AlertModalView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/AlertModalView.swift
@@ -1,0 +1,44 @@
+//
+//  AlertModalView.swift
+//  Muje
+//
+//  Created by Air on 8/25/25.
+//
+
+import SwiftUI
+
+struct AlertModalView: View {
+    @Binding var uploadPostViewModel: UploadPostViewModel
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            Text(uploadPostViewModel.alertContents[0])
+                .multilineTextAlignment(.center)
+                .foregroundStyle(Color.black)
+                .frame(height: 60)
+            
+            Spacer()
+            
+            Button(action: {
+                print(uploadPostViewModel.alertContents[1])
+                uploadPostViewModel.isQuit = false
+            }, label: {
+                ActionButton(title: uploadPostViewModel.alertContents[1], condition: false)
+            })
+            
+            Button(action: {
+                uploadPostViewModel.isQuit = false
+            }, label: {
+                Text(uploadPostViewModel.alertContents[2])
+                    .foregroundStyle(Color.gray)
+            })
+        }
+        .hvPadding(16, 48)
+        .presentationDragIndicator(.hidden)
+        .presentationDetents([.height(240)])
+    }
+}
+
+#Preview {
+    AlertModalView(uploadPostViewModel: .constant(.init()))
+}

--- a/Muje/Muje/Modules/UploadPost/Views/PostInfoView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/PostInfoView.swift
@@ -1,0 +1,134 @@
+//
+//  PostInfoView.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct PostInfoView: View {
+    @Bindable var postInfoViewModel: PostInfoViewModel
+    
+    
+    var body: some View {
+        ZStack {
+            VStack(spacing: 32) {
+                CustomInput(title: "공고제목", tempTitle: "공고 제목을 적어주세요", textValue: $postInfoViewModel.title, maxLength: 100)
+                CustomInput(title: "단체명", tempTitle: "단체명을 적어주세요", textValue: $postInfoViewModel.organization, maxLength: 50)
+                
+                PostDatePicker(title: "모집 마감일", content: postInfoViewModel.endDateString, function: {
+                    postInfoViewModel.isPicker = true
+                })
+                
+                imageView
+                
+                contentView
+                
+            }
+            .padding(.bottom, 160)
+            .onChange(of: postInfoViewModel.selectedItems) { old, new in
+                postInfoViewModel.selectedImagesData.removeAll()
+                if new.count == 5 {
+                    postInfoViewModel.showToast = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        postInfoViewModel.showToast = false
+                    }
+                }
+                Task {
+                    let loadingTasks = new.map { item in
+                        Task {
+                            try? await item.loadTransferable(type: Data.self)
+                        }
+                    }
+                    var imageData: [Data] = []
+                    for task in loadingTasks {
+                        if let data = await task.value {
+                            imageData.append(data)
+                        }
+                    }
+                    await MainActor.run {
+                        postInfoViewModel.selectedImagesData = imageData
+                    }
+                }
+            }
+            .toast(isShown: $postInfoViewModel.showToast, message: "사진은 최대 5장까지만 업로드할 수 있어요", alignment: .bottom)
+        }
+    }
+    
+    
+    
+    private var imageView: some View {
+        VStack(alignment: .leading) {
+            HStack(spacing: 4) {
+                Text("사진")
+                Text("최대 5장")
+                    .font(.caption)
+                    .foregroundStyle(Color.gray)
+            }
+            
+            ScrollView(.horizontal) {
+                HStack(spacing: 8) {
+                    PhotosPicker(selection: $postInfoViewModel.selectedItems, maxSelectionCount: 5, selectionBehavior: .ordered, matching: .images) {
+                        ZStack {
+                            VStack(spacing: 2) {
+                                Image(systemName: "photo.fill.on.rectangle.fill")
+                                Text("\(postInfoViewModel.selectedItems.count)/5")
+                            }
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color.gray.opacity(0.2))
+                                .frame(width: 84, height: 84)
+                        }
+                        .foregroundStyle(Color.gray)
+                    }
+                    
+                    ForEach(postInfoViewModel.selectedImagesData.indices, id: \.self) { index in
+                        let imageData = postInfoViewModel.selectedImagesData[index]
+                        if let uiImage = UIImage(data: imageData) {
+                            ZStack(alignment: .topTrailing) {
+                                Image(uiImage: uiImage)
+                                    .resizable()
+                                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                                    .frame(width: 84, height: 84)
+                                    .scaledToFill()
+                                
+                                Button(action: {
+                                    postInfoViewModel.removeImage(at: index)
+                                }, label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(Color.gray)
+                                        .padding(5)
+                                })
+                            }
+                        }
+                    }
+                }
+                .animation(.spring(), value: postInfoViewModel.selectedImagesData)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+    
+    private var contentView: some View {
+        VStack(alignment: .leading) {
+            Text("모집 내용")
+            TextField("활동 목적, 모집 인원, 활동 일정, 지원 자격 등을 자유롭게 작성해주세요", text: $postInfoViewModel.content, axis: .vertical)
+                .maxLength(text: $postInfoViewModel.content, 2000)
+                .lineLimit(2...)
+                .frame(minHeight: 168, alignment: .top)
+                .bold()
+                .padding(18)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.clear)
+                        .strokeBorder(Color.gray.opacity(0.2), lineWidth: 1)
+                )
+        }
+    }
+}
+
+
+#Preview {
+    PostInfoView(postInfoViewModel: .init())
+}

--- a/Muje/Muje/Modules/UploadPost/Views/PostInterviewView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/PostInterviewView.swift
@@ -1,0 +1,18 @@
+//
+//  PostInterviewView.swift
+//  Muje
+//
+//  Created by Air on 8/25/25.
+//
+
+import SwiftUI
+
+struct PostInterviewView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    PostInterviewView()
+}

--- a/Muje/Muje/Modules/UploadPost/Views/UploadPostView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/UploadPostView.swift
@@ -1,0 +1,126 @@
+//
+//  UploadPostView.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+
+import SwiftUI
+
+struct UploadPostView: View {
+    @State var uploadPostViewModel = UploadPostViewModel()
+    @State var postInfoViewModel = PostInfoViewModel()
+    
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .bottom) {
+                ScrollView {
+                    VStack(alignment: .leading) {
+                        StatusView(uploadPostViewModel: $uploadPostViewModel)
+                        
+                        Spacer()
+                        
+                        if uploadPostViewModel.currentStatus == .input {
+                            PostInfoView(postInfoViewModel: postInfoViewModel)
+                        } else if uploadPostViewModel.currentStatus == .interview {
+                            PostInterviewView()
+                        }
+                        
+                    }
+                    .safeAreaPadding(.horizontal, 16)
+                }
+                
+                nextButtonView
+                
+                if postInfoViewModel.isPicker {
+                    dateView
+                }
+                    
+            }
+            .ignoresSafeArea(edges: .bottom)
+            .navigationTitle("모임 올리기")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading, content: {
+                    Button(action: {
+                        uploadPostViewModel.isQuit = true
+                    }, label: {
+                        Image(systemName: "chevron.left")
+                            .foregroundStyle(Color.gray)
+                    })
+                })
+            }
+            .sheet(isPresented: $uploadPostViewModel.isQuit) {
+                AlertModalView(uploadPostViewModel: $uploadPostViewModel)
+            }
+        }
+    }
+    
+    private var nextButtonView: some View {
+        ZStack(alignment: .top) {
+            Rectangle()
+                .fill(Color.white)
+                .frame(height: 120)
+                .border(Color.gray.opacity(0.2))
+            
+            if uploadPostViewModel.currentStatus == .input {
+                Button(action: {
+                    uploadPostViewModel.currentStatus = .interview
+                    postInfoViewModel.debug()
+                }, label: {
+                    ActionButton(title: "다음", condition: postInfoViewModel.nextCheck())
+                        .hvPadding(16, 20)
+                })
+                .disabled(postInfoViewModel.nextCheck())
+                
+            } else if uploadPostViewModel.currentStatus == .interview {
+                HStack {
+                    Button(action: {
+                        uploadPostViewModel.currentStatus = .input
+                    }, label: {
+                        ActionButton(title: "이전", condition: true)
+                    })
+                    Spacer()
+                    Button(action: {
+                        print("다음")
+                    }, label: {
+                        ActionButton(title: "다음", condition: true)
+                    })
+                }
+                .hvPadding(16, 20)
+            }
+        }
+    }
+    
+    private var dateView: some View {
+        ZStack {
+            Rectangle()
+                .fill(Color.black.opacity(0.4))
+                .ignoresSafeArea()
+                .onTapGesture {
+                    postInfoViewModel.isPicker = false
+                }
+            
+            DatePicker("", selection: $postInfoViewModel.endDate, in: postInfoViewModel.dateRange, displayedComponents: .date)
+                .background(content: {
+                    RoundedRectangle(cornerRadius: 20)
+                        .fill(Color.white)
+                        .offset(y: 12)
+                })
+                .datePickerStyle(.graphical)
+                .onChange(of: postInfoViewModel.endDate, {
+                    postInfoViewModel.connectDate()
+                })
+                .padding(.horizontal, 24)
+        }
+        .ignoresSafeArea()
+    }
+}
+
+
+
+#Preview {
+    UploadPostView()
+}

--- a/Muje/Muje/Resource/Extension/TextField+.swift
+++ b/Muje/Muje/Resource/Extension/TextField+.swift
@@ -1,0 +1,14 @@
+//
+//  TextField+.swift
+//  Muje
+//
+//  Created by Air on 8/24/25.
+//
+
+import SwiftUI
+
+extension TextField {
+    func maxLength(text: Binding<String>, _ maxLength: Int) -> some View {
+        return ModifiedContent(content: self, modifier: MaxLengthModifier(text: text, maxLength: maxLength))
+    }
+}

--- a/Muje/Muje/Resource/Extension/View+.swift
+++ b/Muje/Muje/Resource/Extension/View+.swift
@@ -31,5 +31,20 @@ extension View {
     func paddingH16() -> some View {
         self.padding(.horizontal, 16)
     }
+    
+    //토스트 형식 경고 컴포넌트 사용 모디파이어
+    func toast(isShown: Binding<Bool>, message: String, alignment: Alignment = .bottom) -> some View {
+        ZStack {
+            self
+            Toast(isShown: isShown, message: message)
+        }
+    }
+    
+    //상하, 좌우 여백 통합 모디파이어 ex)hvPadding(12, 24) -> horizontal: 12, vertical: 24
+    func hvPadding(_ h: CGFloat, _ v: CGFloat) -> some View {
+            self
+                .padding(.horizontal, h)
+                .padding(.vertical, v)
+        }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 작업 이슈 번호를 입력해주세요
- Closes #14  <issue-number>


## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 작업 시 사진도 같이 올려주세요.) ]
- 6. 모집글 작성 페이지 UI 구현
- 모집글 작성 과정 상태별로 관리
- 각 입력 내용 글자 수 제한 설정
- 모집날짜 시작은 당일로 고정, 끝은 시작 이후로만 선택 가능하도록 설정
- 이미지 추가, 삭제 기능 구현
- 버튼 조건에 따라 활성화되도록 구현

## 📋 시연 영상
(영상이 너무 커서 업로드가 안되네요)


## 📄 추가 설명
	- UploadPostStatus_Enum
		- 공고 업로드할 때 필요한 과정을 Enum으로 나눠서 관리하기 위해 생성
	- Components
		- ActionButton
			- '다음'으로 넘어가기 위한 버튼 UI(기능 X)
		- CustomInput
			- 커스텀한 TextField, 상단 제목과 PlaceHolder가 존재하고 최대 글자 수를 지정할 수 있다.
		- MaxLengthModifier
			- 텍스트 필드에 최대 글자 수를 지정할 수 있는 모디파이어
		- PostDatePicker
			- 커스텀 데이트피커UI, 그냥 버튼으로 DatePicker 뷰를 부를 때 사용
		- StatusView
			- UploadPostStatus로 지정한 상태들을 나타내는 뷰
		- Toast
			- 사진을 5개 선택할 때, 나오는 경고 메세지 -> 내용을 지정해줄 수 있다.
	- View(-> ViewModel)
		- UploadPostView
			- 공고 업로드 과정을 모두 담고 있는 뷰, 탭뷰 느낌으로 생각하면 될 것 같다.
			- -> 한 뷰에서 3개의 데이터를 합쳐서 서버에 전달
		- PostInfoView
			- 공고 상세내용을 입력하는 뷰
		- PostInterviewView
			- 공고 인터뷰 내용을 설정하는 뷰(추후에 구현)
		- +)AlertModalView
			- 공고 업로드를 나갈 때, 등장하는 모달 화면
	- Extension
		- TextField
			- MaxLength -> 텍스트 필드에 최대 글자 개수 정하는 기능
		- View
			- toast -> 토스트 경고 화면
			- hvPadding -> 수평, 수직 순으로 패딩을 한 줄로 적을 수 있는 기능



