### PR TITLE
✨ [feat]#27 - 7. 면접 일정 설정 UI 구현

### DIFF
--- a/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/EditPostView/CustomTextField.swift
+++ b/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/EditPostView/CustomTextField.swift
@@ -12,6 +12,7 @@ struct CustomTextField: View {
     var tempTitle: String
     var textValue: Binding<String>
     var subTitle: String?
+    let maxLength: Int
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -26,6 +27,7 @@ struct CustomTextField: View {
                 Text(title)
             }
             TextField(tempTitle, text: textValue, axis: .vertical)
+                .maxLength(text: textValue, maxLength)
                 .bold()
                 .padding(18)
                 .background(

--- a/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/EditPostView/EditPostView.swift
+++ b/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/EditPostView/EditPostView.swift
@@ -18,12 +18,12 @@ struct EditPostView: View {
           CustomTextField(
             title: "공고제목",
             tempTitle: "공고 제목을 적어주세요",
-            textValue: $viewModel.title
+            textValue: $viewModel.title, maxLength: 100
           )
           CustomTextField(
             title: "단체명",
             tempTitle: "단체명을 적어주세요",
-            textValue: $viewModel.organization
+            textValue: $viewModel.organization, maxLength: 50
           )
           PickerView(
             title: "모집 마감일",
@@ -132,6 +132,8 @@ struct EditPostView: View {
     VStack(alignment: .leading) {
       Text("모집 내용")
       TextField("활동 목적, 모집 인원, 활동 일정, 지원 자격 등을 자유롭게 작성해주세요", text: $viewModel.content, axis: .vertical)
+        .maxLength(text: $viewModel.content, 2000)
+        .lineLimit(2...)
         .frame(minHeight: 168, alignment: .top)
         .bold()
         .padding(18)

--- a/Muje/Muje/Modules/UploadPost/Calendar/CalendarDay.swift
+++ b/Muje/Muje/Modules/UploadPost/Calendar/CalendarDay.swift
@@ -1,0 +1,16 @@
+//
+//  CalendarDay.swift
+//  Muje
+//
+//  Created by Air on 8/29/25.
+//
+
+import Foundation
+
+struct CalendarDay: Identifiable {
+    var id: UUID = .init()
+    let day: Int
+    let date: Date
+    let isCurrentMonth: Bool
+    let isToday: Bool
+}

--- a/Muje/Muje/Modules/UploadPost/Calendar/CalendarViewModel.swift
+++ b/Muje/Muje/Modules/UploadPost/Calendar/CalendarViewModel.swift
@@ -1,0 +1,114 @@
+//
+//  CalendarViewModel.swift
+//  Muje
+//
+//  Created by Air on 8/29/25.
+//
+
+import SwiftUI
+
+@Observable
+class CalendarViewModel {
+    var currentMonth: Date
+    var selectedDate: Date
+    var calendar: Calendar
+    
+    var selectedDates: [Date] = []
+    
+    var currentMonthYear: Int {
+        Calendar.current.component(.year, from: currentMonth)
+    }
+    
+    let localizedWeekdaysSymbols: [String] = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.shortWeekdaySymbols ?? []
+    }()
+    
+    let calendarHeaderDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월"
+        return formatter
+    }()
+    
+    init(currentMonth: Date = Date(), selectedDate: Date = Date(), calendar: Calendar = Calendar.current) {
+        self.currentMonth = currentMonth
+        self.selectedDate = selectedDate
+        self.calendar = calendar
+    }
+    
+    func changeMonth(by value: Int) {
+        let calendar = Calendar.current
+        if let newMonth = calendar.date(byAdding: .month, value: value, to: currentMonth) {
+            currentMonth = newMonth
+        }
+    }
+    
+    func daysForCurrentGrid() -> [CalendarDay] {
+        let calendar = Calendar.current
+        
+        let firstDay = firstDayOfMonth()
+        let firstWeekDay = calendar.component(.weekday, from: firstDay)
+        let daysInMonth = numberOfDays(in: currentMonth)
+        
+        var days: [CalendarDay] = []
+        
+        let leadingDays = (firstWeekDay - calendar.firstWeekday + 7) % 7
+        
+        if leadingDays > 0, let previousMonth = calendar.date(byAdding: .month, value: -1, to: currentMonth) {
+            let daysInPreviousMonth = numberOfDays(in: previousMonth)
+            for i in 0..<leadingDays {
+                let day = daysInPreviousMonth - leadingDays + 1 + i
+                if let date = calendar.date(bySetting: .day, value: day, of: previousMonth) {
+                    days.append(CalendarDay(day: day, date: date, isCurrentMonth: false, isToday: false))
+                }
+            }
+        }
+        
+        for day in 1...daysInMonth {
+            var components = calendar.dateComponents([.year, .month], from: currentMonth)
+            components.day = day
+            components.hour = 0
+            components.minute = 0
+            components.second = 0
+            
+            if let date = calendar.date(from: components) {
+                if date.dateString.contains(Date.now.dateString) {
+                    days.append(CalendarDay(day: day, date: date, isCurrentMonth: true, isToday: true))
+                } else {
+                    days.append(CalendarDay(day: day, date: date, isCurrentMonth: true, isToday: false))
+                }
+            }
+        }
+        
+        let remaining = (7 - days.count % 7) % 7
+        if remaining > 0,
+           let nextMonth = calendar.date(byAdding: .month, value: 1, to: currentMonth) {
+            let  daysInNextMonth = numberOfDays(in: nextMonth)
+            
+            for day in 1...remaining {
+                let validDay = min(day, daysInNextMonth)
+                if let date = calendar.date(bySetting: .day, value: validDay, of: nextMonth) {
+                    days.append(CalendarDay(day: day, date: date, isCurrentMonth: false, isToday: false))
+                }
+            }
+        }
+//        print(days)
+        return days
+    }
+    
+    func numberOfDays(in date: Date) -> Int {
+        Calendar.current.range(of: .day, in: .month, for: date)?.count ?? 0
+    }
+    
+    private func firstWeekDayOfMonth(id date: Date) -> Int {
+        let components = Calendar.current.dateComponents([.year, .month], from: date)
+        let firstDay = Calendar.current.date(from: components)!
+        return Calendar.current.component(.weekday, from: firstDay)
+    }
+    
+    func firstDayOfMonth() -> Date {
+        let components = Calendar.current.dateComponents([.year, .month], from: currentMonth)
+        return Calendar.current.date(from: components) ?? Date()
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/Calendar/Cell.swift
+++ b/Muje/Muje/Modules/UploadPost/Calendar/Cell.swift
@@ -1,0 +1,57 @@
+//
+//  Cell.swift
+//  Muje
+//
+//  Created by Air on 8/29/25.
+//
+
+import SwiftUI
+
+struct Cell: View {
+    var calendarDay: CalendarDay
+    
+    @Bindable var calendarViewModel: CalendarViewModel
+    var startDate: Date
+    var endDate: Date
+    @State var isSelectedAble: Bool = false
+    @State var isSelected: Bool = true
+    
+    var body: some View {
+        ZStack {
+            if isSelectedAble {
+                Circle()
+                    .fill(Color.yellow.opacity(0.6))
+                    .frame(width: 26, height: 27)
+                    .transition(.scale.combined(with: .opacity))
+            }
+            
+            Text("\(calendarDay.day)")
+                .font(.caption)
+                .foregroundStyle(textColor)
+                .animation(.easeInOut(duration: 0.2), value: calendarViewModel.selectedDate)
+        }
+        .frame(height: 30)
+        .task {
+            selectSlot(date: calendarDay.date, startDate: startDate, endDate: endDate)
+        }
+        .onChange(of: endDate) {
+            selectSlot(date: calendarDay.date, startDate: startDate, endDate: endDate)
+        }
+    }
+    
+    private var textColor: Color {
+        if calendarDay.isCurrentMonth {
+            if calendarDay.isToday {
+                return Color.blue
+            } else {
+                return Color.black
+            }
+        } else {
+            return Color.gray.opacity(0.4)
+        }
+    }
+    
+    func selectSlot(date: Date, startDate: Date, endDate: Date) {
+        self.isSelectedAble = (startDate < date && date < endDate)
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/Component/CountButton.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/CountButton.swift
@@ -1,0 +1,44 @@
+//
+//  CountButton.swift
+//  Muje
+//
+//  Created by Air on 8/29/25.
+//
+
+import SwiftUI
+
+struct CountButton: View {
+    @Binding var value: Int
+    
+    var title: String
+    var count: Int
+    var unit: String
+    var condition: Bool?
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(title)
+            HStack(spacing: 32) {
+                Button(action: {
+                    self.value -= count
+                }, label: {
+                    Image(systemName: "minus")
+                })
+                .disabled((value - count) <= 0)
+                
+                Text("\(value)\(unit)")
+                
+                Button(action: {
+                    self.value += count
+                }, label: {
+                    Image(systemName: "plus")
+                })
+                .disabled(condition ?? false)
+            }
+        }
+    }
+}
+
+#Preview {
+    CountButton(value: .constant(1), title: "qwer", count: 2, unit: "SS")
+}

--- a/Muje/Muje/Modules/UploadPost/Component/CustomDatePicker.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/CustomDatePicker.swift
@@ -1,0 +1,49 @@
+//
+//  CustomDatePicker.swift
+//  Muje
+//
+//  Created by Air on 8/30/25.
+//
+
+import SwiftUI
+
+struct CustomDatePicker: UIViewRepresentable {
+    @Binding var date: Date
+    
+    var minuteInterval: Int
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> UIDatePicker {
+        let datePicker = UIDatePicker()
+        datePicker.datePickerMode = .time
+        datePicker.preferredDatePickerStyle = .wheels
+        datePicker.minuteInterval = minuteInterval
+        
+        datePicker.addTarget(
+            context.coordinator,
+            action: #selector(Coordinator.dateChanged(_:)),
+            for: .valueChanged
+        )
+        return datePicker
+    }
+
+    func updateUIView(_ uiView: UIDatePicker, context: Context) {
+        uiView.minuteInterval = minuteInterval
+        uiView.setDate(date, animated: true)
+    }
+
+    class Coordinator: NSObject {
+        var parent: CustomDatePicker
+
+        init(_ parent: CustomDatePicker) {
+            self.parent = parent
+        }
+
+        @objc func dateChanged(_ sender: UIDatePicker) {
+            parent.date = sender.date
+        }
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/Component/InterviewButton.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/InterviewButton.swift
@@ -1,0 +1,30 @@
+//
+//  InterviewButton.swift
+//  Muje
+//
+//  Created by Air on 8/29/25.
+//
+
+import SwiftUI
+
+struct InterviewButton: View {
+    var condition: Bool? = nil
+    var value: Bool
+    var title: String
+    
+    var body: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(Color.gray.opacity(0.2))
+            .stroke(condition == value ? Color.purple : Color.clear, lineWidth: 1)
+            .frame(height: 56)
+            .overlay(content: {
+                Text(title)
+                    .foregroundStyle(condition == value ? Color.purple : Color.secondary)
+                    .bold()
+            })
+    }
+}
+
+#Preview {
+    InterviewButton(value: false, title: "qwer")
+}

--- a/Muje/Muje/Modules/UploadPost/Model/InterviewSlotModel.swift
+++ b/Muje/Muje/Modules/UploadPost/Model/InterviewSlotModel.swift
@@ -1,0 +1,18 @@
+//
+//  InterviewSlotModel.swift
+//  Muje
+//
+//  Created by Air on 8/29/25.
+//
+
+import SwiftUI
+
+struct InterviewSlotModel: Identifiable {
+    let id: UUID = .init() //슬롯 아이디
+    var postId: String //포스트 아이디(공고ID받아옴)
+    var interviewDate: Date //면접 날짜
+    var interviewTime: Date //면접 시간
+    var maxCapacity: Int //면접 한 타임 당 최대 인원
+    var currentReservations: Int //현재 예약된 인원
+    var createdAt: Date //생성 시간
+}

--- a/Muje/Muje/Modules/UploadPost/Model/TimeModel.swift
+++ b/Muje/Muje/Modules/UploadPost/Model/TimeModel.swift
@@ -1,0 +1,25 @@
+//
+//  TimeModel.swift
+//  Muje
+//
+//  Created by Air on 8/29/25.
+//
+
+import Foundation
+
+//지원자 기준
+struct TimeModel: Hashable {
+    var startTime: Date
+    var endTime: Date
+    var isStartShown: Bool
+    var isEndShown: Bool
+    var timeLists: [Date]
+    
+//    init(startTime: Date, endTime: Date, isStartShown: Bool, isEndShown: Bool, timeLists: [Date]) {
+//        self.startTime = startTime
+//        self.endTime = endTime
+//        self.isStartShown = isStartShown
+//        self.isEndShown = isEndShown
+//        self.timeLists = timeLists
+//    }
+}

--- a/Muje/Muje/Modules/UploadPost/ViewModels/InterviewSlotViewModel.swift
+++ b/Muje/Muje/Modules/UploadPost/ViewModels/InterviewSlotViewModel.swift
@@ -1,0 +1,121 @@
+//
+//  InterviewSlotViewModel.swift
+//  Muje
+//
+//  Created by Air on 8/29/25.
+//
+
+import SwiftUI
+
+
+@Observable
+class InterviewSlotViewModel {
+    var selectedSlots: [TimeModel] = []
+    var maxCount: Int = 1
+    var timeInterval: Int = 30
+    
+    //배열 오름차순으로 정렬하는 조건
+    let ascending: (TimeModel, TimeModel) -> Bool = { (lhs, rhs) in
+        return lhs.startTime < rhs.startTime
+    }
+    
+    var interviewSlotLists: [InterviewSlotModel] = [] //인터뷰 슬롯 DTO에 필요
+    
+    //슬롯들 시간 순으로 정렬하는 함수
+    func slotUpdate() {
+        self.selectedSlots.sort(by: ascending)
+    }
+    
+    func checkSlot(date: Date, startDate: Date, endDate: Date) -> Bool {
+        return !(startDate <= date && date < endDate)
+    }
+    
+    //캘린더 슬롯을 누르면 인터뷰 시간을 설정할 수 있는 피커 리스트 생성
+    func createPicker(calendarDay: CalendarDay) {
+        var timeSlots: [Date] {
+            var slots: [Date] = []
+            var currentTime = calendarDay.date.setTo9AM()
+            
+            while currentTime <= calendarDay.date.endOfDay() {
+                slots.append(currentTime)
+                if let nextTime = Calendar.current.date(byAdding: .minute, value: timeInterval, to: currentTime) {
+                    currentTime = nextTime
+                } else {
+                    break
+                }
+            }
+            return slots
+        }
+        selectedSlots.append(.init(startTime: calendarDay.date.setTo9AM(), endTime: calendarDay.date.setTo9AM().addingTimeInterval(TimeInterval(60 * timeInterval)), isStartShown: false, isEndShown: false, timeLists: timeSlots))
+    }
+    
+    //선택된 캘린더 슬롯에서 당일 인터뷰 슬롯 생성하는 함수
+    func generateSlot(from startTime: Date, to endTime: Date) {
+        let title = "post_ID"
+        
+        let calendar = Calendar.current
+        var currentDate = startTime
+        
+        while currentDate <= endTime {
+            let model = InterviewSlotModel(postId: title, interviewDate: currentDate, interviewTime: currentDate, maxCapacity: maxCount, currentReservations: 0, createdAt: .now)
+            interviewSlotLists.append(model)
+            guard let nextDate = calendar.date(byAdding: .minute, value: timeInterval, to: currentDate) else {
+                break
+            }
+            currentDate = nextDate
+        }
+    }
+    
+    //선택된 캘린더 슬롯에서 모든 시간 당 인터뷰 슬롯 생성하는 함수 -> 인터뷰 슬롯 리스트에 저장됨
+    func updateAllSlot() {
+        for list in selectedSlots {
+            generateSlot(from: list.startTime, to: list.endTime)
+        }
+    }
+    
+    //인터뷰 시작 시간이 변경될 때마다 인터뷰 종료 피커들을 변경하는 함수
+    func updateSlotTime(slot: Binding<TimeModel>) {
+        slot.endTime.wrappedValue = slot.startTime.wrappedValue.addingTimeInterval(TimeInterval(60 * timeInterval))
+        var timeSlots: [Date] {
+            var slots: [Date] = []
+            var currentTime = slot.startTime.wrappedValue
+            
+            while currentTime <= slot.startTime.wrappedValue.endOfDay() {
+                slots.append(currentTime)
+                if let nextTime = Calendar.current.date(byAdding: .minute, value: timeInterval, to: currentTime) {
+                    currentTime = nextTime
+                } else {
+                    break
+                }
+            }
+            return slots
+        }
+        slot.timeLists.wrappedValue = timeSlots
+    }
+    
+    //인터뷰 슬롯의 시작 날짜와 종료 날짜를 출력하는 함수
+    func datePrint() -> String {
+        if interviewSlotLists.isEmpty {
+            return "시작일 ~ 마감일 설정"
+        } else {
+            return "\(interviewSlotLists.first?.interviewTime.shortDateString ?? "시작오류") ~ \(interviewSlotLists.last?.interviewTime.shortDayString ?? "끝 오류")"
+        }
+    }
+    
+    func slotDebug() {
+        print("maxCapacity: \(maxCount)")
+        print("timeInterval: \(timeInterval)")
+        
+        for slot in interviewSlotLists {
+            if interviewSlotLists.first?.id == slot.id {
+                print("postID: \(slot.postId)")
+                print("currentReservation: \(slot.currentReservations)")
+                print("---------------------------------")
+            }
+            
+            print("\(slot.interviewDate.shortDateString)")
+            print("\(slot.interviewTime.hourMinute24)")
+            
+        }
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/ViewModels/PostInterviewViewModel.swift
+++ b/Muje/Muje/Modules/UploadPost/ViewModels/PostInterviewViewModel.swift
@@ -5,4 +5,21 @@
 //  Created by Air on 8/25/25.
 //
 
-import Foundation
+import SwiftUI
+
+@Observable
+class PostInterviewViewModel {
+    var isSheet: Bool = false
+    
+    var hasInterview: Bool? = nil
+    var interviewLocation: String = ""
+    
+    func nextCheck() -> Bool {
+        return hasInterview == nil
+    }
+    
+    func debug() {
+        print("인터뷰 진행여부: \(hasInterview ?? false)")
+        print("인터뷰 장소 \(interviewLocation)")
+    }
+}

--- a/Muje/Muje/Modules/UploadPost/Views/InterviewSlotView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/InterviewSlotView.swift
@@ -1,0 +1,158 @@
+//
+//  InterviewSlotView.swift
+//  Muje
+//
+//  Created by Air on 8/29/25.
+//
+
+import SwiftUI
+
+struct InterviewSlotView: View {
+    @State var calendarViewModel: CalendarViewModel = .init()
+    
+    @Bindable var postInfoViewModel: PostInfoViewModel
+    @Bindable var postInterviewViewModel: PostInterviewViewModel
+    @Bindable var interviewSlotViewModel: InterviewSlotViewModel
+        
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            ScrollView {
+                VStack(spacing: 24, content: {
+                    headerController
+                    
+                    calendarView
+                    
+                    slotSettingView
+                    
+                    slotListView
+                })
+                .hvPadding(16, 30)
+                .background(Color.white)
+            }
+            
+            Button(action: {
+                postInterviewViewModel.isSheet = false
+                interviewSlotViewModel.updateAllSlot()
+                interviewSlotViewModel.slotDebug()
+            }, label: {
+                ActionButton(title: "등록", condition: false)
+                    .padding(.horizontal, 16)
+            })
+        }
+    }
+    
+    private var headerController: some View {
+        HStack(spacing: 47, content: {
+            Button(action: {
+                calendarViewModel.changeMonth(by: -1)
+            }, label: {
+                Image(systemName: "chevron.left")
+            })
+            
+            Text(calendarViewModel.currentMonth, formatter: calendarViewModel.calendarHeaderDateFormatter)
+                .font(.title3)
+                .foregroundStyle(Color.black)
+            
+            Button(action: {
+                calendarViewModel.changeMonth(by: 1)
+            }, label: {
+                Image(systemName: "chevron.right")
+            })
+        })
+    }
+    
+    private var calendarView: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 7), spacing: 5, content: {
+            ForEach(calendarViewModel.localizedWeekdaysSymbols.indices, id: \.self) { index in
+                Text(calendarViewModel.localizedWeekdaysSymbols[index])
+                    .foregroundStyle(Color.gray)
+                    .frame(maxWidth: .infinity)
+                    .font(.caption)
+            }
+            .padding(.bottom, 30)
+            
+            ForEach(calendarViewModel.daysForCurrentGrid(), id: \.id) { calendarDay in
+                Button(action: {
+                    interviewSlotViewModel.createPicker(calendarDay: calendarDay)
+                }, label: {
+                    Cell(calendarDay: calendarDay, calendarViewModel: calendarViewModel, startDate: postInfoViewModel.startDate, endDate: postInfoViewModel.endDate)
+                })
+                .disabled(interviewSlotViewModel.checkSlot(date: calendarDay.date, startDate: postInfoViewModel.startDate, endDate: postInfoViewModel.endDate))
+            }
+        })
+        .frame(height: 250, alignment: .top)
+    }
+    
+    private var slotSettingView: some View {
+        HStack {
+            CountButton(value: $interviewSlotViewModel.maxCount, title: "한 타임 당 면접 인원", count: 1, unit: "명")
+            
+            Spacer()
+            
+            CountButton(value: $interviewSlotViewModel.timeInterval, title: "한 타임 당 면접 시간", count: 10, unit: "분", condition: interviewSlotViewModel.timeInterval == 30)
+        }
+        .padding(.horizontal, 24)
+        .onChange(of: interviewSlotViewModel.timeInterval) {
+            interviewSlotViewModel.selectedSlots.removeAll()
+        }
+    }
+    
+    private var slotListView: some View {
+        VStack {
+            if interviewSlotViewModel.selectedSlots.isEmpty {
+                delayView
+            } else {
+                ForEach(Array($interviewSlotViewModel.selectedSlots.enumerated()), id: \.offset) { idx, slot in
+                    HStack(spacing: 24) {
+                        Button(action: {
+                            interviewSlotViewModel.selectedSlots.remove(at: idx)
+                        }, label: {
+                            Image(systemName: "xmark")
+                            
+                        })
+                        Spacer()
+                        Text(interviewSlotViewModel.selectedSlots[idx].startTime.shortDateString)
+                        Spacer()
+                        Button(action: {
+                            interviewSlotViewModel.selectedSlots[idx].isStartShown.toggle()
+                        }, label: {
+                            Text(interviewSlotViewModel.selectedSlots[idx].startTime.hourMinute24)
+                                .startPicker(isShown: interviewSlotViewModel.selectedSlots[idx].isStartShown, date: slot.startTime)
+                        })
+                        Button(action: {
+                            interviewSlotViewModel.selectedSlots[idx].isEndShown.toggle()
+                        }, label: {
+                            Text(interviewSlotViewModel.selectedSlots[idx].endTime.hourMinute24)
+                                .endPicker(isShown: interviewSlotViewModel.selectedSlots[idx].isEndShown, endTime: slot.endTime, lists: interviewSlotViewModel.selectedSlots[idx].timeLists)
+                        })
+                        .onChange(of: slot.startTime.wrappedValue) {
+                            interviewSlotViewModel.updateSlotTime(slot: slot)
+                        }
+                    }
+                    .padding()
+                }
+            }
+        }
+        .onChange(of: interviewSlotViewModel.selectedSlots) {
+            interviewSlotViewModel.slotUpdate()
+        }
+    }
+    
+    private var delayView: some View {
+        VStack(spacing: 24) {
+            Text("날짜를 선택하세요")
+            Spacer()
+            Text("공고 작성을 완료한 후에도 \n면접일정을 설정할 수 있어요")
+            Button(action: {
+                postInterviewViewModel.isSheet = false
+            }, label: {
+                Text("다음에 하기")
+            })
+        }
+        .padding(.vertical, 18)
+    }
+}
+
+#Preview {
+    InterviewSlotView(postInfoViewModel: .init(), postInterviewViewModel: .init(), interviewSlotViewModel: .init())
+}

--- a/Muje/Muje/Modules/UploadPost/Views/PostInterviewView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/PostInterviewView.swift
@@ -8,11 +8,77 @@
 import SwiftUI
 
 struct PostInterviewView: View {
+    @Bindable var postInfoViewModel: PostInfoViewModel
+    @Bindable var postInterviewViewModel: PostInterviewViewModel
+    @State var interviewSlotViewModel = InterviewSlotViewModel()
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading, spacing: 32) {
+            Text("면접 여부는 모집글 작성이 완려되면 수정할 수 없어요")
+                .foregroundStyle(Color.gray)
+            
+            HStack {
+                Button(action: {
+                    postInterviewViewModel.hasInterview = true
+                }, label: {
+                    InterviewButton(condition: postInterviewViewModel.hasInterview, value: true, title: "예")
+                })
+                Spacer()
+                Button(action: {
+                    postInterviewViewModel.hasInterview = false
+                }, label: {
+                    InterviewButton(condition: postInterviewViewModel.hasInterview, value: false, title: "아니요")
+                })
+            }
+            
+            if let condition = postInterviewViewModel.hasInterview {
+                if condition == true {
+                    interviewSettingView
+                }
+            }
+            
+            Spacer()
+            
+        }
+        .sheet(isPresented: $postInterviewViewModel.isSheet, content: {
+            InterviewSlotView(postInfoViewModel: postInfoViewModel, postInterviewViewModel: postInterviewViewModel, interviewSlotViewModel: interviewSlotViewModel)
+        })
+    }
+    
+    private var interviewSettingView: some View {
+        VStack {
+            VStack(alignment: .leading) {
+                HStack(spacing: 4) {
+                    Text("면접 일정")
+                    Text("추후 설정 가능")
+                        .font(.caption)
+                        .foregroundStyle(Color.gray)
+                }
+                
+                Button(action: {
+                    print("데이트 피커")
+                    postInterviewViewModel.isSheet.toggle()
+                }, label: {
+                    HStack(spacing: 6) {
+                        Text(interviewSlotViewModel.datePrint())
+                        Spacer()
+                        Image(systemName: "calendar")
+                    }
+                    .foregroundStyle(Color.gray)
+                    .padding(18)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color.gray.opacity(0.2))
+                    )
+                })
+            }
+            
+            CustomTextField(title: "면접 장소", tempTitle: "장소를 입력해주세요", textValue: $postInterviewViewModel.interviewLocation, subTitle: "추후 설정 가능", maxLength: 100)
+        }
     }
 }
 
+
 #Preview {
-    PostInterviewView()
+    PostInterviewView(postInfoViewModel: .init(), postInterviewViewModel: .init())
 }

--- a/Muje/Muje/Modules/UploadPost/Views/UploadPostView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/UploadPostView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct UploadPostView: View {
     @State var uploadPostViewModel = UploadPostViewModel()
     @State var postInfoViewModel = PostInfoViewModel()
+    @State var postInterviewViewModel = PostInterviewViewModel()
     
     var body: some View {
         NavigationStack {
@@ -25,7 +26,7 @@ struct UploadPostView: View {
                         if uploadPostViewModel.currentStatus == .input {
                             PostInfoView(postInfoViewModel: postInfoViewModel)
                         } else if uploadPostViewModel.currentStatus == .interview {
-                            PostInterviewView()
+                            PostInterviewView(postInfoViewModel: postInfoViewModel, postInterviewViewModel: postInterviewViewModel)
                         }
                         
                     }
@@ -85,9 +86,11 @@ struct UploadPostView: View {
                     Spacer()
                     Button(action: {
                         print("다음")
+                        postInterviewViewModel.debug()
                     }, label: {
-                        ActionButton(title: "다음", condition: true)
+                        ActionButton(title: "다음", condition: postInterviewViewModel.nextCheck())
                     })
+                    .disabled(postInterviewViewModel.nextCheck())
                 }
                 .hvPadding(16, 20)
             }

--- a/Muje/Muje/Resource/Extension/Date+.swift
+++ b/Muje/Muje/Resource/Extension/Date+.swift
@@ -107,6 +107,22 @@ extension Date {
         return df.string(from: self)
     }
     
+    func setTo9AM() -> Date {
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: self)
+        let nineAM = calendar.date(byAdding: .hour, value: 9, to: startOfToday) ?? Date()
+        
+        return nineAM
+    }
+    
+    func endOfDay() -> Date {
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: self)
+        let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? Date()
+        
+        return endOfDay
+    }
+    
     private static let cachedDateFormatter: DateFormatter = {
         let f = DateFormatter()
         return f

--- a/Muje/Muje/Resource/Extension/View+.swift
+++ b/Muje/Muje/Resource/Extension/View+.swift
@@ -40,6 +40,33 @@ extension View {
         }
     }
     
+    func startPicker(isShown: Bool, date: Binding<Date>) -> some View {
+        ZStack {
+            self
+            if isShown {
+                CustomDatePicker(date: date, minuteInterval: 5)
+                    .frame(width: 200)
+                    .background(Color.white)
+            }
+        }
+    }
+    
+    func endPicker(isShown: Bool, endTime: Binding<Date>, lists: [Date]) -> some View {
+        ZStack {
+            self
+            if isShown {
+                Picker("", selection: endTime) {
+                    ForEach(lists, id: \.self) { date in
+                        Text(date.hourMinute24)
+                            .tag(date)
+                    }
+                }
+                .pickerStyle(.wheel)
+                .background(Color.white)
+            }
+        }
+    }
+    
     //상하, 좌우 여백 통합 모디파이어 ex)hvPadding(12, 24) -> horizontal: 12, vertical: 24
     func hvPadding(_ h: CGFloat, _ v: CGFloat) -> some View {
             self
@@ -47,4 +74,3 @@ extension View {
                 .padding(.vertical, v)
         }
 }
-


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 작업 이슈 번호를 입력해주세요
- Closes #27 


## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 작업 시 사진도 같이 올려주세요.) ]
Todo)
- 7번 UI 구현
- 인터뷰 슬롯 모델을 DTO에 따라서 변경
- 캘린더 슬롯과 인터뷰 슬롯 로직 연결
- UploadPostView와 연결

추가설명)
- Calendar -> 캘린더 기능 구현 폴더
  - CalendarDay -> 캘린더 모델 
  - CalendarViewModel -> 캘린더 뷰 모델
  - Cell -> 캘린더 슬롯 뷰
- Component
  - CountButton - 인터뷰 슬롯 뷰에서 슬롯 설정 버튼
  - InterviewButton - 인터뷰 진행 여부를 정하는 버튼
- Extension
  - Date
    - setTo9AM - Date 타입을 오전 9시로 맞추는 함수
    - endOfDat - Date 타입을 하루 마지막으로 맞추는 함수
  - VIew
    - startPicker - 인터뷰 시작 시간을 설정하는 피커
    - endPicker - 인터뷰 종료 시간을 설정하는 피커
- Model
  - InterviewSlotModel - InterviewSlot DTO를 위한 데이터 모델
  - TimeModel - 데이트 피커를 관리하는 데이터 모델
- ViewModel
  - InterviewSlotViewModel
  - PostInterviewViewModel
- View
  - InterviewSlotView - 면접 타임 설정하는 뷰
  - PostInterviewView - 면접 총 관리 뷰

## 📋 시연 영상
(용량이 너무 크다)




