### PR TITLE
Feat/#51 공고 현황 로직 개선 / 네비게이션 연결

### DIFF
--- a/Muje/Muje/App/MujeApp.swift
+++ b/Muje/Muje/App/MujeApp.swift
@@ -99,6 +99,7 @@ struct MujeApp: App {
     @StateObject var push = NotificationCoordinator()
     @StateObject private var deepLink = DeepLinkController.shared
     @StateObject private var unreadBadge = UnreadBadgeStore()
+    @StateObject private var globalUIState = GlobalUIState()
     
     @State private var isReady = false
     @State private var bootError: String?
@@ -194,6 +195,7 @@ struct MujeApp: App {
             .environmentObject(unreadBadge)
             .environmentObject(deepLink)
             .environmentObject(FirebaseAuthManager.shared) // 파이어베이스 Auth 의존성 주입
+            .environmentObject(globalUIState)
         }
     }
     

--- a/Muje/Muje/App/MujeApp.swift
+++ b/Muje/Muje/App/MujeApp.swift
@@ -100,6 +100,7 @@ struct MujeApp: App {
     @StateObject private var deepLink = DeepLinkController.shared
     @StateObject private var unreadBadge = UnreadBadgeStore()
     @StateObject private var globalUIState = GlobalUIState()
+    @StateObject private var tabSelection = TabSelection()
     
     @State private var isReady = false
     @State private var bootError: String?
@@ -196,6 +197,7 @@ struct MujeApp: App {
             .environmentObject(deepLink)
             .environmentObject(FirebaseAuthManager.shared) // 파이어베이스 Auth 의존성 주입
             .environmentObject(globalUIState)
+            .environmentObject(tabSelection)
         }
     }
     

--- a/Muje/Muje/App/MujeApp.swift
+++ b/Muje/Muje/App/MujeApp.swift
@@ -99,6 +99,7 @@ struct MujeApp: App {
     @StateObject var push = NotificationCoordinator()
     @StateObject private var deepLink = DeepLinkController.shared
     @StateObject private var unreadBadge = UnreadBadgeStore()
+    @StateObject private var globalUIState = GlobalUIState()
     
     @State private var isReady = false
     @State private var bootError: String?
@@ -198,6 +199,7 @@ struct MujeApp: App {
             .environmentObject(unreadBadge)
             .environmentObject(deepLink)
             .environmentObject(FirebaseAuthManager.shared) // 파이어베이스 Auth 의존성 주입
+            .environmentObject(globalUIState)
         }
     }
     

--- a/Muje/Muje/App/MujeApp.swift
+++ b/Muje/Muje/App/MujeApp.swift
@@ -100,6 +100,7 @@ struct MujeApp: App {
     @StateObject private var deepLink = DeepLinkController.shared
     @StateObject private var unreadBadge = UnreadBadgeStore()
     @StateObject private var globalUIState = GlobalUIState()
+    @StateObject private var tabSelection = TabSelection()
     
     @State private var isReady = false
     @State private var bootError: String?
@@ -200,6 +201,7 @@ struct MujeApp: App {
             .environmentObject(deepLink)
             .environmentObject(FirebaseAuthManager.shared) // 파이어베이스 Auth 의존성 주입
             .environmentObject(globalUIState)
+            .environmentObject(tabSelection)
         }
     }
     

--- a/Muje/Muje/Common/Components/Custom/PostListItem.swift
+++ b/Muje/Muje/Common/Components/Custom/PostListItem.swift
@@ -42,60 +42,25 @@ struct PostListItem: View {
     }
 }
 
-struct ThumbnailAsyncImage: View {
-    let postImage: PostImage?
-    @State private var downloadURL: String?
-    @State private var isLoading: Bool = true
-    
-    var body: some View {
-        Group {
-            if let downloadURL = downloadURL {
-                AsyncImage(url: URL(string: downloadURL)) { image in
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                } placeholder: {
-                    ProgressView()
-                }
-            } else if isLoading {
-                ProgressView()
-            } else {
-                defaultImageView
-            }
-        }
-        .frame(width: 78, height: 78)
-        .clipped()
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .task(id: postImage?.imageId) {
-            await loadDownloadURL()
-        }
-    }
-    private var defaultImageView: some View {
-        Rectangle()
-            .fill(Color.gray.opacity(0.3))
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay(
-                Image(systemName: "photo")
-                    .font(.title3)
-                    .foregroundStyle(.gray)
-            )
-    }
-    private func loadDownloadURL() async {
-        guard let postImage = postImage else {
-            await MainActor.run { self.isLoading = false }
-            return
-        }
-        do {
-            let url = try await postImage.getDownloadURL()
-            await MainActor.run {
-                self.downloadURL = url
-                self.isLoading = false
-            }
-        } catch {
-            await MainActor.run {
-                self.isLoading = false
-            }
-        }
-    }
+#Preview {
+  PostListItem(
+    post: Post(
+      postId: UUID(),
+      authorUserId: "",
+      title: "",
+      organization: "",
+      content: "",
+      recruitmentStart: Timestamp(date: Date()),
+      recruitmentEnd: Timestamp(date: Date()),
+      status: PostStatus.recruiting.rawValue,
+      authorName: "",
+      authorOrganization: ""
+    ),
+    thumbnailImage: PostImage(
+      imageId: UUID(),
+      postId: "",
+      imageUrl: "",
+      imageOrder: 0
+    )
+  )
 }

--- a/Muje/Muje/Common/Components/Custom/ThumbnailAsyncImage.swift
+++ b/Muje/Muje/Common/Components/Custom/ThumbnailAsyncImage.swift
@@ -1,0 +1,66 @@
+//
+//  ThumbnailAsyncImage.swift
+//  Muje
+//
+//  Created by 조재훈 on 9/5/25.
+//
+
+import SwiftUI
+
+struct ThumbnailAsyncImage: View {
+    let postImage: PostImage?
+    @State private var downloadURL: String?
+    @State private var isLoading: Bool = true
+    
+    var body: some View {
+        Group {
+            if let downloadURL = downloadURL {
+                AsyncImage(url: URL(string: downloadURL)) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                } placeholder: {
+                    ProgressView()
+                }
+            } else if isLoading {
+                ProgressView()
+            } else {
+                defaultImageView
+            }
+        }
+        .frame(width: 78, height: 78)
+        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .task(id: postImage?.imageId) {
+            await loadDownloadURL()
+        }
+    }
+    private var defaultImageView: some View {
+        Rectangle()
+            .fill(Color.gray.opacity(0.3))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                Image(systemName: "photo")
+                    .font(.title3)
+                    .foregroundStyle(.gray)
+            )
+    }
+    private func loadDownloadURL() async {
+        guard let postImage = postImage else {
+            await MainActor.run { self.isLoading = false }
+            return
+        }
+        do {
+            let url = try await postImage.getDownloadURL()
+            await MainActor.run {
+                self.downloadURL = url
+                self.isLoading = false
+            }
+        } catch {
+            await MainActor.run {
+                self.isLoading = false
+            }
+        }
+    }
+}

--- a/Muje/Muje/Common/Components/MyPosts/ApplyPostCard.swift
+++ b/Muje/Muje/Common/Components/MyPosts/ApplyPostCard.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ApplyPostCard: View {
+    @EnvironmentObject private var router: NavigationRouter
     @Bindable var selectViewModel: SelectViewModel
     
     var item: Post
@@ -43,7 +44,7 @@ struct ApplyPostCard: View {
                 
                 Divider()
                 ButtonBox(title: "공고글 보기", action: {
-                    print("공고 상세보기로 이동")
+                  router.push(to: .RecruitmentDetailView(postId: item.postId.uuidString))
                 })
             }
         }

--- a/Muje/Muje/Common/Components/MyPosts/RecruitPostCard.swift
+++ b/Muje/Muje/Common/Components/MyPosts/RecruitPostCard.swift
@@ -12,6 +12,8 @@ struct RecruitPostCard: View {
     var isPost: Bool
     
     var tempLists: [InterviewSlotModel] = []
+  
+  @EnvironmentObject private var router: NavigationRouter
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -39,12 +41,21 @@ struct RecruitPostCard: View {
                 })
                 
                 Divider()
-                ButtonBox(title: "지원자 관리", action: {
-                    print("지원자 관리로 이동")
+              ButtonBox(
+                title: "지원자 관리",
+                action: {
+                  print("지원자 관리로 이동")
+                  router.push(
+                    to: .applicationManagementView(
+                      postId: item.postId.uuidString,
+                      postInfo: ApplicationManagementPostInfo(from: item)
+                    )
+                  )
                 })
                 Divider()
                 ButtonBox(title: "작성글 관리", action: {
                     print("공고 상세보기로 이동")
+                  router.push(to: .RecruitmentDetailView(postId: item.postId.uuidString))
                 })
             }
         }

--- a/Muje/Muje/Core/Navigation/NavigationDestination.swift
+++ b/Muje/Muje/Core/Navigation/NavigationDestination.swift
@@ -26,6 +26,7 @@ enum NavigationDestination: Equatable, Hashable {
       customQuestion: [CustomQuestion],
       questionAnswer: [String: String]
   )
+    case applicationCompleteView
     case editContentView(post: Post, postImages: [PostImage])
     case applicationManagementView(
       postId: String,

--- a/Muje/Muje/Core/Navigation/NavigationRoutingView.swift
+++ b/Muje/Muje/Core/Navigation/NavigationRoutingView.swift
@@ -45,6 +45,8 @@ struct NavigationRoutingView: View {
                 customQuestion: customQuestion,
                 questionAnswer: .constant(questionAnswer)
               )
+            case .applicationCompleteView:
+              ApplicationCompleteView()
             case .applicationManagementView(let postId, let postInfo):
               ApplicationManagementView(
                 postId: postId,

--- a/Muje/Muje/Core/Notification/GlobalUIState.swift
+++ b/Muje/Muje/Core/Notification/GlobalUIState.swift
@@ -1,0 +1,12 @@
+//
+//  GlobalUIState.swift
+//  Muje
+//
+//  Created by 조재훈 on 9/4/25.
+//
+
+import Foundation
+
+class GlobalUIState: ObservableObject {
+  @Published var showEditToast = false
+}

--- a/Muje/Muje/Core/Notification/TabSelection.swift
+++ b/Muje/Muje/Core/Notification/TabSelection.swift
@@ -1,0 +1,12 @@
+//
+//  TabCase.swift
+//  Muje
+//
+//  Created by 조재훈 on 9/5/25.
+//
+
+import Foundation
+
+class TabSelection: ObservableObject {
+  @Published var tabCase: TabCase = .home
+}

--- a/Muje/Muje/Modules/Home/Views/ApplicationPreView/ApplicationCompleteView.swift
+++ b/Muje/Muje/Modules/Home/Views/ApplicationPreView/ApplicationCompleteView.swift
@@ -1,0 +1,96 @@
+//
+//  UploadCompleteView.swift
+//  Muje
+//
+//  Created by 조재훈 on 8/30/25.
+//
+
+import SwiftUI
+
+struct ApplicationCompleteView: View {
+  @EnvironmentObject private var router: NavigationRouter
+  @EnvironmentObject private var tabSelection: TabSelection
+  
+  var body: some View {
+    VStack(alignment: .leading) {
+      title
+      Spacer()
+      grapics
+      Spacer()
+    }
+    .toolbar {
+      ToolbarCenterTitle(text: "신청서 작성")
+    }
+    .padding(.top, 32)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.horizontal, 16)
+    .safeAreaInset(edge: .bottom, content: {
+      bottomButton
+    })
+    .navigationTitle("모임 올리기")
+    .navigationBarTitleDisplayMode(.inline)
+  }
+  
+  private var title: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("신청서가 제출되었어요!")
+        .font(.title2)
+        .foregroundStyle(Color.black)
+        .bold()
+      Text("모집자에게 신청이 전달되었어요\n합격 발표 알림을 기다려주세요")
+        .font(.system(size: 14))
+        .foregroundStyle(.gray)
+        .lineSpacing(3)
+    }
+  }
+  
+  private var grapics: some View {
+    VStack {
+      Text("그래픽 어떻게 넣는거지?")
+    }
+  }
+  
+  private var bottomButton: some View {
+    HStack {
+      Button {
+        router.popToRootView()
+        tabSelection.tabCase = .myPosts
+      } label: {
+        Text("나의 모임 페이지")
+          .padding()
+          .frame(maxWidth: .infinity)
+          .background(
+            RoundedRectangle(cornerRadius: 10)
+              .fill(Color.gray)
+          )
+      }
+      Button {
+        router.popToRootView()
+      } label: {
+        Text("홈으로")
+          .padding()
+          .frame(maxWidth: .infinity)
+          .background(
+            RoundedRectangle(cornerRadius: 10)
+              .fill(Color.black)
+          )
+      }
+    }
+    .hvPadding(16, 20)
+    .frame(maxWidth: .infinity)
+    .background(
+      Rectangle()
+        .fill(Color.white)
+        .shadow(radius: 3)
+        .ignoresSafeArea(edges: .bottom)
+    )
+    
+  }
+}
+
+#Preview {
+  NavigationStack {
+    ApplicationCompleteView()
+  }
+  .environmentObject(NavigationRouter())
+}

--- a/Muje/Muje/Modules/Home/Views/ApplicationPreView/ApplicationPreview.swift
+++ b/Muje/Muje/Modules/Home/Views/ApplicationPreView/ApplicationPreview.swift
@@ -106,6 +106,7 @@ struct ApplicationPreview: View {
             customQuestion: customQuestion
           )
         }
+        router.push(to: .applicationCompleteView)
       } label: {
         Text("확인")
           .foregroundStyle(.white)

--- a/Muje/Muje/Modules/Home/Views/ApplicationPreView/ApplicationPreview.swift
+++ b/Muje/Muje/Modules/Home/Views/ApplicationPreView/ApplicationPreview.swift
@@ -20,6 +20,7 @@ struct ApplicationPreview: View {
   
   @State private var viewModel = ApplicationPreviewModel()
   
+  private let userId: String = "0062C371-34F5-470B-BFE1-F671E23C5C97"
   
   var body: some View {
     VStack(spacing: 0) {
@@ -43,7 +44,7 @@ struct ApplicationPreview: View {
     }
   }
     .task {
-      await viewModel.loadUserData(userId: postId)
+      await viewModel.loadUserData(userId: userId)
     }
     
     bottomButtonSection

--- a/Muje/Muje/Modules/Home/Views/HomeView.swift
+++ b/Muje/Muje/Modules/Home/Views/HomeView.swift
@@ -55,7 +55,9 @@ struct HomeView: View {
                 .contentMargins(.horizontal, 16, for: .scrollContent)
                 .contentMargins(.horizontal, 0, for: .scrollIndicators)
             } //: VSTACK
-            PostCreateButton(action: {}) //TODO: 라우터 연결
+          PostCreateButton(action: {
+            router.push(to: .uploadPostView)
+          })
                 .padding(.bottom, 24)
         } //: ZSTACK
         .task {

--- a/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/EditPostView/EditContentView.swift
+++ b/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/EditPostView/EditContentView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import FirebaseFirestore
 
 struct EditContentView: View {
+  @EnvironmentObject private var globalUIState: GlobalUIState
+  @EnvironmentObject private var router: NavigationRouter
   @State private var viewModel: EditPostViewModel
   
   init(post: Post, postImages: [PostImage]) {
@@ -23,13 +25,15 @@ struct EditContentView: View {
         }
         .safeAreaPadding(.horizontal, 16)
       }
-      bottomButton
       
       if viewModel.isPicker {
         dateView
       }
+      
     }
-    .ignoresSafeArea(edges: .bottom)
+    .safeAreaInset(edge: .bottom) {
+      bottomButton
+    }
   }
   
   private var dateView: some View {
@@ -57,23 +61,32 @@ struct EditContentView: View {
   
   private var bottomButton: some View {
     VStack {
-      Spacer()
       Button {
         Task {
           await viewModel.updatedPost()
+          router.pop()
+          globalUIState.showEditToast = true
         }
       } label: {
         Text("수정 저장하기")
-          .font(.system(size: 18))
-          .foregroundStyle(.white)
+          .body1SemiBold18()
+          .foregroundStyle(.white01)
+          .padding()
           .frame(maxWidth: .infinity)
-          .padding(.vertical, 20)
-          .background(Color.black)
-          .clipShape(RoundedRectangle(cornerRadius: 10))
+          .background(
+            RoundedRectangle(cornerRadius: 10)
+              .fill(Color.primaryBlack)
+          )
       }
     }
-    .padding(.horizontal, 16)
-    .padding(.vertical, 20)
+    .hvPadding(16, 20)
+    .frame(maxWidth: .infinity)
+    .background(
+      Rectangle()
+        .fill(Color.white)
+        .shadow(radius: 3)
+        .ignoresSafeArea(edges: .bottom)
+    )
   }
 }
 
@@ -99,4 +112,5 @@ struct EditContentView: View {
       createdAt: Timestamp(date: Date())
     )]
   )
+  .environmentObject(GlobalUIState())
 }

--- a/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/EditPostView/EditPostView.swift
+++ b/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/EditPostView/EditPostView.swift
@@ -14,27 +14,30 @@ struct EditPostView: View {
   
   var body: some View {
     ZStack {
-        VStack(spacing: 32) {
-          CustomTextField(
-            title: "공고제목",
-            tempTitle: "공고 제목을 적어주세요",
-            textValue: $viewModel.title, maxLength: 100
-          )
-          CustomTextField(
-            title: "단체명",
-            tempTitle: "단체명을 적어주세요",
-            textValue: $viewModel.organization, maxLength: 50
-          )
-          PickerView(
-            title: "모집 마감일",
-            content: viewModel.endDateString,
-            function: {
-              viewModel.isPicker = true
-            })
-          imageView
-          contentView
-        }
-        .padding(.bottom, 100)
+      VStack(spacing: 32) {
+        CustomTextField(
+          title: "공고제목",
+          tempTitle: "공고 제목을 적어주세요",
+          textValue: $viewModel.title, maxLength: 100
+        )
+        CustomTextField(
+          title: "단체명",
+          tempTitle: "단체명을 적어주세요",
+          textValue: $viewModel.organization, maxLength: 50
+        )
+        PickerView(
+          title: "모집 마감일",
+          content: viewModel.endDateString,
+          function: {
+            viewModel.isPicker = true
+          })
+        imageView
+        contentView
+      }
+      .padding(.bottom, 100)
+//      .safeAreaInset(edge: .bottom) {
+//        bottomButton
+//      }
     }
   }
   
@@ -58,7 +61,7 @@ struct EditPostView: View {
           
           // 새 이미지들 표시
           selectedImageView
-
+          
         }
         .animation(.spring(), value: viewModel.selectedImagesData)
       }
@@ -99,9 +102,9 @@ struct EditPostView: View {
         onDelete: { viewModel.removeExistingImage(at: index) },
         cachedURL: (viewModel.imageURLCache[postImage.imageId]) ?? ""
       )
-//            ExistingImageCard(postImage: postImage) {
-//              viewModel.removeExistingImage(at: index)
-//            }
+      //            ExistingImageCard(postImage: postImage) {
+      //              viewModel.removeExistingImage(at: index)
+      //            }
     }
   }
   // MARK: - PhotosPicker에서 선택된 이미지
@@ -145,9 +148,33 @@ struct EditPostView: View {
     }
   }
   
-
-  
-
+  private var bottomButton: some View {
+    VStack {
+      Button {
+        Task {
+          await viewModel.updatedPost()
+        }
+      } label: {
+        Text("수정 저장하기")
+          .body1SemiBold18()
+          .foregroundStyle(.white01)
+          .padding()
+          .frame(maxWidth: .infinity)
+          .background(
+            RoundedRectangle(cornerRadius: 10)
+              .fill(Color.primaryBlack)
+          )
+      }
+    }
+    .hvPadding(16, 20)
+    .frame(maxWidth: .infinity)
+    .background(
+      Rectangle()
+        .fill(Color.white)
+        .shadow(radius: 3)
+        .ignoresSafeArea(edges: .bottom)
+    )
+  }
 }
 
 // MARK: - 기존 이미지 카드 (getDownloadURL 사용)
@@ -177,7 +204,7 @@ struct ExistingImageCard: View {
             .frame(width: 84, height: 84)
             .overlay(
               ProgressView().scaleEffect(0.8)
-              )
+            )
         } else {
           if let downloadURL = downloadURL {
             AsyncImage(url: URL(string: downloadURL)) { image in
@@ -199,9 +226,9 @@ struct ExistingImageCard: View {
           .padding(5)
       }
     }
-      .task(id: postImage.imageId) {
-        await loadDownloadURL()
-      }
+    .task(id: postImage.imageId) {
+      await loadDownloadURL()
+    }
     
   }
   
@@ -225,4 +252,29 @@ struct ExistingImageCard: View {
       }
     }
   }
+}
+
+#Preview {
+  EditPostView(
+    viewModel: EditPostViewModel.init(
+      post: Post(
+        postId: UUID(),
+        authorUserId: "",
+        title: "",
+        organization: "",
+        content: "",
+        recruitmentStart: Timestamp(date: Date()),
+        recruitmentEnd: Timestamp(date: Date()),
+        status: PostStatus.recruiting.rawValue,
+        authorName: "",
+        authorOrganization: ""
+      ),
+      postImages: [PostImage(
+        imageId: UUID(),
+        postId: "",
+        imageUrl: "",
+        imageOrder: 0
+      )]
+    )
+  )
 }

--- a/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/RecruitmentDetailView.swift
+++ b/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/RecruitmentDetailView.swift
@@ -11,6 +11,7 @@ struct RecruitmentDetailView: View {
   
   @State private var viewModel = RecruitmentViewModel()
   @EnvironmentObject private var router: NavigationRouter
+  @EnvironmentObject private var globalUIState: GlobalUIState
   
   let postId: String
   
@@ -29,7 +30,9 @@ struct RecruitmentDetailView: View {
         action: { router.pop() },
         fixAction: {
           guard let post = viewModel.post else { return }
-          router.push(to: .editContentView(post: post, postImages: viewModel.postImages))},
+          router.push(to: .editContentView(post: post, postImages: viewModel.postImages))
+          
+        },
         reportAction: {}, // 신고하기 화면 이동
         deleteAction: { Task { await viewModel.deletePostInfo(for: postId) } }
       )
@@ -39,10 +42,22 @@ struct RecruitmentDetailView: View {
         router.popToRootView()
       }
     }
+    .onChange(of: globalUIState.showEditToast, { oldValue, newValue in
+      if newValue {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+          globalUIState.showEditToast = false
+        }
+      }
+    })
     .task {
       await viewModel.loadPostDetail(for: postId)
       await viewModel.preloadImageURL()
     }
+    .toast(
+      isShown: $globalUIState.showEditToast,
+      message: "공고가 수정 되었어요",
+      alignment: .bottom
+    )
     .navigationBarBackButtonHidden()
     .ignoresSafeArea(.all, edges: .top)
   }
@@ -111,4 +126,5 @@ enum loadingCase {
 #Preview {
   RecruitmentDetailView(postId: "mock_id")
     .environmentObject(NavigationRouter())
+    .environmentObject(GlobalUIState())
 }

--- a/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/TopButtonView/TopButtonView.swift
+++ b/Muje/Muje/Modules/Home/Views/RecruitmentDetailView/TopButtonView/TopButtonView.swift
@@ -41,7 +41,10 @@ struct TopButtonView: View {
       ReportModalView(
         showReportModal: $showReportModal,
         isAuthor: isAuthor,
-        fixAction: fixAction,
+        fixAction: {
+          fixAction()
+          showReportModal = false
+        },
         reportAction: reportAction,
         deleteAction: deleteAction
       )

--- a/Muje/Muje/Modules/MyPosts/ViewModels/MyPostsViewModel.swift
+++ b/Muje/Muje/Modules/MyPosts/ViewModels/MyPostsViewModel.swift
@@ -143,8 +143,8 @@ extension MyPostsViewModel {
     isLoading = true
     defer {
       isLoading = false
-      lastLoadTime = Date()
-      isDataLoaded = true
+//      lastLoadTime = Date()
+//      isDataLoaded = true
     }
     
     print("서버 로딩 시작")

--- a/Muje/Muje/Modules/MyPosts/ViewModels/MyPostsViewModel.swift
+++ b/Muje/Muje/Modules/MyPosts/ViewModels/MyPostsViewModel.swift
@@ -46,6 +46,52 @@ class MyPostsViewModel {
   var applicationPost: [Post] = []
   var applicationSlot: [UUID: [InterviewSlot]] = [:]
   var applicationThumbnail: [UUID: PostImage] = [:]
+  
+  // MARK: 캐싱 관련
+  private var lastLoadTime: Date?
+  private var isDataLoaded: Bool = false
+  private let cacheValidDuration: TimeInterval = 300
+  
+  
+  // MARK: - 캐시 함수
+  // 캐시 유효한지 확인 (기준 5분)
+  private var isCacheValid: Bool {
+    guard let lastLoadTime = lastLoadTime else { return false }
+    return Date().timeIntervalSince(lastLoadTime) < cacheValidDuration
+  }
+  // 캐시 상태 확인
+  private func logCacheStatus() {
+    if let lastLoadTime = lastLoadTime {
+      let timeSinceLoad = Date().timeIntervalSince(lastLoadTime)
+      print("마지막 로드: \(Int(timeSinceLoad))초 전, 캐시 유효함")
+    } else {
+      print("첫 로드")
+    }
+  }
+  @MainActor
+  func forceRefresh() async {
+    print("새로 고침")
+    currentRecruitPage = 0
+    currentApplyPage = 0
+    
+    clearCache()
+    await loadAllDataIfNeed(forceReload: true)
+  }
+  
+  private func clearCache() {
+    lastLoadTime = nil
+    isDataLoaded = false
+    
+    currentUserApplication.removeAll()
+    uploadPost.removeAll()
+    uploadPostSlot.removeAll()
+    uploadThumbnail.removeAll()
+    applicationPost.removeAll()
+    applicationSlot.removeAll()
+    applicationThumbnail.removeAll()
+    
+    print("캐시 클리어 완료")
+  }
     
     func upcomingRecruitLists() -> [InterviewSlotModel] {
         let upcomingDates = recruitmentLists.filter { slot in
@@ -77,10 +123,31 @@ class MyPostsViewModel {
 }
 // MARK: - 파이어베이스 로직
 extension MyPostsViewModel {
+  func loadAllDataIfNeed(forceReload: Bool = false) async {
+    guard !isLoading else {
+      print("이미 로딩 중")
+      return
+    }
+    logCacheStatus()
+    
+    if !forceReload && isCacheValid && isDataLoaded {
+      print("캐시 데이터 사용하여 서버 호출 스킵")
+      return
+    }
+    
+    await loadAllData()
+  }
+  
   // MARK: 모든 데이터 병렬 함수
   func loadAllData() async {
     isLoading = true
-    defer { isLoading = false }
+    defer {
+      isLoading = false
+      lastLoadTime = Date()
+      isDataLoaded = true
+    }
+    
+    print("서버 로딩 시작")
     
     await withTaskGroup(of: Void.self) { group in
       group.addTask {
@@ -98,53 +165,21 @@ extension MyPostsViewModel {
     do {
       let app = try await currentUserApplication(for: userId)
       self.currentUserApplication = mapDicApp(for: app)
+      print("현재 유저의 지원서\(app.count)개 로드")
+      
+      let uniquePostIds = Set(app.compactMap { $0.postId })
+      let uniquePostUUIDs =
+      uniquePostIds.compactMap { UUID(uuidString:  $0)}
       
       await withTaskGroup(of: Void.self) { group in
-        for i in app {
-          group.addTask {
-            do {
-              let post = try await self.fetchApplicationPost(for: i.postId)
-              print("지원한 공고 갯수 \(post.count)개 로드 성공")
-              
-              await MainActor.run {
-                self.applicationPost = post
-              }
-              
-            } catch {
-              print("\(userId)가 지원한 공고 정보 불러오기 실패")
-            }
-          }
-          group.addTask {
-            do {
-              let slot = try await self.fetchInterviewSlot(for: i.postId)
-              print("지원한 공고의 인터뷰 슬롯 \(slot.count)개 로드 성공")
-              
-              await MainActor.run {
-                self.applicationSlot = self.mapDicSlot(for: slot)
-                print("\(self.applicationSlot.count)")
-              }
-              
-            } catch {
-              print("\(userId)가 지원한 인터뷰 슬롯 불러오기 실패")
-            }
-          }
-          group.addTask {
-            do {
-              let postIds: [UUID] = app.compactMap {
-                UUID(
-                  uuidString: $0.postId
-                )
-              }
-              let thumb = try await self.firestoreManager.fetchThumbnailsForPost(for: postIds)
-              print("지원한 공고의 썸네일 \(thumb.count)개 로드 성공")
-              
-              await MainActor.run {
-                self.applicationThumbnail = thumb
-              }
-            } catch {
-              print("\(userId)가 지원한 공고의 썸네일 불러오기 실패 \(error)")
-            }
-          }
+        group.addTask {
+          await self.loadApplicationPosts(postIds: Array(uniquePostIds))
+        }
+        group.addTask {
+          await self.loadApplicationSlots(postIds: Array(uniquePostIds))
+        }
+        group.addTask {
+          await self.loadApplicationThumbnails(postUUIDs: uniquePostUUIDs)
         }
       }
     } catch {
@@ -160,38 +195,160 @@ extension MyPostsViewModel {
       print("내가 작성한 공고 \(posts.count)개 로드 성공")
       self.uploadPost = posts
       
+      let postIds = posts.map { $0.postId.uuidString }
+      let postUUIDs = posts.map { $0.postId }
+      
       await withTaskGroup(of: Void.self) { group in
-        for post in posts {
-          group.addTask {
-            do {
-              let slots = try await self.fetchInterviewSlot(for: post.postId.uuidString)
-              print("내가 작성한 공고 인터뷰 슬롯 \(slots.count)개 로드 성공")
-              await MainActor.run {
-                self.uploadPostSlot = self.mapDicSlot(for: slots)
-                print("\(self.uploadPostSlot.count)")
-              }
-            } catch {
-              print("\(post.postId)의 인터뷰 슬롯 불러오기 실패 \(error)")
-            }
-          }
-          group.addTask {
-            do {
-              let postId = posts.compactMap { $0.postId }
-              let thumb = try await self.firestoreManager.fetchThumbnailsForPost(for: postId)
-              print("내가 작성한 공고 썸네일 \(thumb.count)개 로드 성공")
-              
-              await MainActor.run {
-                self.uploadThumbnail = thumb
-              }
-              
-            } catch {
-              print("썸네일 불러오기 실패: \(error)")
-            }
-          }
+        group.addTask {
+          await self.loadUploadSlots(postIds: postIds)
+        }
+        group.addTask {
+          await self.loadUploadThumbnails(postUUIDs: postUUIDs)
         }
       }
     } catch {
       print("내가 올린 공고 로드 실패 \(error)")
+    }
+  }
+}
+// MARK: - 개별 데이터 로딩 함수
+private extension MyPostsViewModel {
+  func loadApplicationPosts(postIds: [String]) async {
+    do {
+      let allPosts = await withTaskGroup(of: [Post].self, returning: [Post].self) { group in
+        for postId in postIds {
+          group.addTask {
+            do {
+              return try await self.fetchApplicationPost(for: postId)
+            } catch {
+              print("\(postId) 공고 불러오기 실패")
+              return []
+            }
+          }
+        }
+        // 전체 데이터 결과
+        var results: [Post] = []
+        for await posts in group {
+          results.append(contentsOf: posts)
+        }
+        return results
+      }
+      // 실제 변수에 담은 (UI 업데이트)
+      await MainActor.run {
+        for post in allPosts {
+          if !self.applicationPost.contains(where: { $0.postId == post.postId }) {
+            self.applicationPost.append(post)
+          }
+        }
+      }
+      print("지원한 공고 정보 \(allPosts.count)개 로드 성공")
+    }
+  }
+  
+  func loadApplicationSlots(postIds: [String]) async {
+    do {
+      let allSlots = await withTaskGroup(of: [InterviewSlot].self, returning: [InterviewSlot].self) { group in
+        for postId in postIds {
+          group.addTask {
+            do {
+              return try await self.fetchInterviewSlot(for: postId)
+            } catch {
+              print("\(postId)의 인터뷰 슬롯 로딩 실패")
+              return []
+            }
+          }
+        }
+        
+        var results: [InterviewSlot] = []
+        for await slots in group {
+          results.append(contentsOf: slots)
+        }
+        return results
+      }
+      
+      await MainActor.run {
+        let newSlotDic = self.mapDicSlot(for: allSlots)
+        
+        for (key, value) in newSlotDic {
+          if self.applicationSlot[key] != nil {
+            let existingSlotIds = Set(self.applicationSlot[key]?.map { $0.slotId } ?? [])
+            let newSlots = value.filter { !existingSlotIds.contains($0.slotId) }
+            self.applicationSlot[key]?.append(contentsOf: newSlots)
+          } else {
+            self.applicationSlot[key] = value
+          }
+        }
+      }
+      print("지원한 공고의 면접 슬롯 \(allSlots.count)개 로드 완료")
+    }
+  }
+  
+  func loadApplicationThumbnails(postUUIDs: [UUID]) async {
+    guard !postUUIDs.isEmpty else { return }
+    
+    do {
+      let thumbnails = try await firestoreManager.fetchThumbnailsForPost(for: postUUIDs)
+      
+      await MainActor.run {
+        self.applicationThumbnail.merge(thumbnails) { _, new in new }
+      }
+      print("지원한 공고의 썸네일 \(thumbnails.count)개 로드 완료")
+    } catch {
+      print("지원한 공고 썸네일 로딩 실패 \(error)")
+    }
+  }
+  
+  func loadUploadSlots(postIds: [String]) async {
+    do {
+      let allSlots = await withTaskGroup(of: [InterviewSlot].self, returning: [InterviewSlot].self) { group in
+        for postId in postIds {
+          group.addTask {
+            do {
+              return try await self.fetchInterviewSlot(for: postId)
+            } catch {
+              print("\(postId)의 모집한 인터뷰 슬롯 로드 실패")
+              return []
+            }
+          }
+        }
+        
+        var results: [InterviewSlot] = []
+        for await slots in group {
+          results.append(contentsOf: slots)
+        }
+        return results
+      }
+      
+      await MainActor.run {
+        let newSlotDic = self.mapDicSlot(for: allSlots)
+        
+        for (key, value) in newSlotDic {
+          if self.uploadPostSlot[key] != nil {
+            let existingSlotIds = Set(self.uploadPostSlot[key]?.map { $0.slotId } ?? [] )
+            let newSlots = value.filter { !existingSlotIds.contains($0.slotId) }
+            self.uploadPostSlot[key]?.append(contentsOf: newSlots)
+          } else {
+            self.uploadPostSlot[key] = value
+          }
+        }
+      }
+      
+      print("내가 올린 공고 면접 슬롯 \(allSlots.count)개 로드 완료")
+    }
+  }
+  
+  func loadUploadThumbnails(postUUIDs: [UUID]) async {
+    guard !postUUIDs.isEmpty else { return }
+    
+    do {
+      let thumbnails = try await firestoreManager.fetchThumbnailsForPost(for: postUUIDs)
+      
+      await MainActor.run {
+        self.uploadThumbnail.merge(thumbnails) { _, new in new }
+      }
+      print("내가 올린 공고 썸네일 \(thumbnails.count)개 로드 완료")
+    } catch {
+      print("내가 올린 공고 썸네일 로딩 실패 \(error)")
     }
   }
 }

--- a/Muje/Muje/Modules/MyPosts/Views/ApplicationManagement/ApplicationManagementView.swift
+++ b/Muje/Muje/Modules/MyPosts/Views/ApplicationManagement/ApplicationManagementView.swift
@@ -10,6 +10,8 @@ import FirebaseFirestore
 
 struct ApplicationManagementView: View {
   
+  @EnvironmentObject private var router: NavigationRouter
+  
   @State var viewModel: ApplicationManagementViewModel = .init()
   @FocusState var isSearchFieldFocused: Bool
   
@@ -23,7 +25,7 @@ struct ApplicationManagementView: View {
     VStack(spacing: 0) {
       CustomNavigationBar(
         title: "내가 올린 공고") {
-          // 네비게이션 연결
+          router.pop()
         }
       ScrollViewReader { proxy in
         ScrollView {

--- a/Muje/Muje/Modules/MyPosts/Views/ApplicationManagement/ListSection/ListSection.swift
+++ b/Muje/Muje/Modules/MyPosts/Views/ApplicationManagement/ListSection/ListSection.swift
@@ -56,7 +56,8 @@ extension ApplicationManagementView {
               .multilineTextAlignment(.center)
               .foregroundStyle(.gray)
           } else {
-            Text("\(viewModel.selectedManagementStage.displayName) 단계에\n지원자가 없습니다.")
+//            Text("\(viewModel.selectedManagementStage.displayName) 단계에\n지원자가 없습니다.")
+            Text("지원자가 없습니다.")
               .multilineTextAlignment(.center)
           }
         }

--- a/Muje/Muje/Modules/MyPosts/Views/MyPostsView.swift
+++ b/Muje/Muje/Modules/MyPosts/Views/MyPostsView.swift
@@ -19,8 +19,15 @@ struct MyPostsView: View {
               applyView
           }
         }
-        .task {
-          await myPostsViewModel.loadAllData()
+        .onAppear {
+          Task {
+            await myPostsViewModel.loadAllDataIfNeed()
+          }
+        }
+        .refreshable {
+          Task {
+            await myPostsViewModel.forceRefresh()
+          }
         }
         .safeAreaPadding(.horizontal, 16)
         .fullScreenCover(isPresented: $selectViewModel.isSetting) {

--- a/Muje/Muje/Modules/MyPosts/Views/MyPostsView.swift
+++ b/Muje/Muje/Modules/MyPosts/Views/MyPostsView.swift
@@ -19,16 +19,19 @@ struct MyPostsView: View {
               applyView
           }
         }
-        .onAppear {
-          Task {
-            await myPostsViewModel.loadAllDataIfNeed()
-          }
+        .task {
+          await myPostsViewModel.loadAllData()
         }
-        .refreshable {
-          Task {
-            await myPostsViewModel.forceRefresh()
-          }
-        }
+//        .onAppear {
+//          Task {
+//            await myPostsViewModel.loadAllDataIfNeed()
+//          }
+//        }
+//        .refreshable {
+//          Task {
+//            await myPostsViewModel.forceRefresh()
+//          }
+//        }
         .safeAreaPadding(.horizontal, 16)
         .fullScreenCover(isPresented: $selectViewModel.isSetting) {
             SelectView(selectViewModel: selectViewModel)

--- a/Muje/Muje/Modules/RootView.swift
+++ b/Muje/Muje/Modules/RootView.swift
@@ -12,13 +12,13 @@ struct RootView: View {
     @EnvironmentObject private var router: NavigationRouter
     @EnvironmentObject private var unreadBadge: UnreadBadgeStore
     @EnvironmentObject private var deepLink: DeepLinkController
-    
-    @State private var tabcase: TabCase = .home
+    @EnvironmentObject private var tabSelection: TabSelection
+//    @State private var tabcase: TabCase = .home
     
     
     var body: some View {
         NavigationStack(path: $router.destination) {
-            TabView(selection: $tabcase, content: {
+          TabView(selection: $tabSelection.tabCase, content: {
                 ForEach(TabCase.allCases, id: \.rawValue) { tab in
                     Tab(
                         value: tab,
@@ -54,7 +54,7 @@ struct RootView: View {
     }
     
     private func tabLabel(_ tab: TabCase) -> some View {
-        let isSelected = tabcase == tab
+      let isSelected = tabSelection.tabCase == tab
         return VStack(spacing: 12) {
             Image(tab.icon)
                 .renderingMode(.template)
@@ -63,7 +63,7 @@ struct RootView: View {
                 .font(.caption)
                 .foregroundStyle(Color.black) // FIXME: - 컬러 수정
         }
-        .animation(.snappy, value: tabcase) // 애니메이션 추가
+        .animation(.snappy, value: tabSelection.tabCase) // 애니메이션 추가
     }
     
     @ViewBuilder

--- a/Muje/Muje/Modules/UploadPost/Component/Toast.swift
+++ b/Muje/Muje/Modules/UploadPost/Component/Toast.swift
@@ -13,6 +13,7 @@ struct Toast: View {
     
     var body: some View {
         VStack {
+          Spacer()
             if isShown {
                 HStack(spacing: 16) {
                     Text(message)
@@ -23,6 +24,7 @@ struct Toast: View {
                 .transition(.move(edge: .bottom))
             }
         }
+        .padding(.bottom, 150)
     }
 }
 

--- a/Muje/Muje/Modules/UploadPost/Views/AlertModalView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/AlertModalView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct AlertModalView: View {
     @Binding var uploadPostViewModel: UploadPostViewModel
+  
+    let action: () -> Void
     
     var body: some View {
         VStack(spacing: 24) {
@@ -22,6 +24,7 @@ struct AlertModalView: View {
             Button(action: {
                 print(uploadPostViewModel.alertContents[1])
                 uploadPostViewModel.isQuit = false
+                action()
             }, label: {
                 ActionButton(title: uploadPostViewModel.alertContents[1], condition: false)
             })
@@ -40,5 +43,5 @@ struct AlertModalView: View {
 }
 
 #Preview {
-    AlertModalView(uploadPostViewModel: .constant(.init()))
+  AlertModalView(uploadPostViewModel: .constant(.init()), action: {})
 }

--- a/Muje/Muje/Modules/UploadPost/Views/PostInfoView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/PostInfoView.swift
@@ -23,17 +23,11 @@ struct PostInfoView: View {
                 })
                 
                 imageView
-                
                 contentView
-                
             }
             .padding(.bottom, 160)
-
         }
-        
     }
-    
-    
     
     private var imageView: some View {
         VStack(alignment: .leading) {

--- a/Muje/Muje/Modules/UploadPost/Views/PostInfoView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/PostInfoView.swift
@@ -28,33 +28,9 @@ struct PostInfoView: View {
                 
             }
             .padding(.bottom, 160)
-            .onChange(of: postInfoViewModel.selectedItems) { old, new in
-                postInfoViewModel.selectedImagesData.removeAll()
-                if new.count == 5 {
-                    postInfoViewModel.showToast = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                        postInfoViewModel.showToast = false
-                    }
-                }
-                Task {
-                    let loadingTasks = new.map { item in
-                        Task {
-                            try? await item.loadTransferable(type: Data.self)
-                        }
-                    }
-                    var imageData: [Data] = []
-                    for task in loadingTasks {
-                        if let data = await task.value {
-                            imageData.append(data)
-                        }
-                    }
-                    await MainActor.run {
-                        postInfoViewModel.selectedImagesData = imageData
-                    }
-                }
-            }
-            .toast(isShown: $postInfoViewModel.showToast, message: "사진은 최대 5장까지만 업로드할 수 있어요", alignment: .bottom)
+
         }
+        
     }
     
     

--- a/Muje/Muje/Modules/UploadPost/Views/UploadCompleteView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/UploadCompleteView.swift
@@ -78,7 +78,6 @@ struct UploadCompleteView: View {
         .fill(Color.white)
         .shadow(radius: 3)
         .ignoresSafeArea(edges: .bottom)
-      
     )
     
   }

--- a/Muje/Muje/Modules/UploadPost/Views/UploadCompleteView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/UploadCompleteView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct UploadCompleteView: View {
   @EnvironmentObject private var router: NavigationRouter
+  @EnvironmentObject private var tabSelection: TabSelection
   
   var body: some View {
     VStack(alignment: .leading) {
@@ -23,8 +24,9 @@ struct UploadCompleteView: View {
     .safeAreaInset(edge: .bottom, content: {
       bottomButton
     })
-    .navigationTitle("모임 올리기")
-    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarCenterTitle(text: "모임 올리기")
+    }
   }
   
   private var title: some View {
@@ -49,7 +51,8 @@ struct UploadCompleteView: View {
   private var bottomButton: some View {
     HStack {
       Button {
-        router.push(to: .myPostView)
+        router.popToRootView()
+        tabSelection.tabCase = .myPosts
       } label: {
         Text("나의 모임 페이지")
           .padding()
@@ -84,5 +87,8 @@ struct UploadCompleteView: View {
 }
 
 #Preview {
-  UploadCompleteView()
+  NavigationStack {
+    UploadCompleteView()
+  }
+  .environmentObject(NavigationRouter())
 }

--- a/Muje/Muje/Modules/UploadPost/Views/UploadPostView.swift
+++ b/Muje/Muje/Modules/UploadPost/Views/UploadPostView.swift
@@ -45,13 +45,37 @@ struct UploadPostView: View {
                     }
                     .safeAreaPadding(.horizontal, 16)
                 }
-                
+                .onChange(of: postInfoViewModel.selectedItems) { old, new in
+                    postInfoViewModel.selectedImagesData.removeAll()
+                    if new.count == 5 {
+                        postInfoViewModel.showToast = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                            postInfoViewModel.showToast = false
+                        }
+                    }
+                    Task {
+                        let loadingTasks = new.map { item in
+                            Task {
+                                try? await item.loadTransferable(type: Data.self)
+                            }
+                        }
+                        var imageData: [Data] = []
+                        for task in loadingTasks {
+                            if let data = await task.value {
+                                imageData.append(data)
+                            }
+                        }
+                        await MainActor.run {
+                            postInfoViewModel.selectedImagesData = imageData
+                        }
+                    }
+                }
+                .toast(isShown: $postInfoViewModel.showToast, message: "사진은 최대 5장까지만 업로드할 수 있어요", alignment: .bottom)
                 nextButtonView
                 
                 if postInfoViewModel.isPicker {
                     dateView
                 }
-                    
             }
             .ignoresSafeArea(edges: .bottom)
             .navigationTitle("모임 올리기")
@@ -67,7 +91,9 @@ struct UploadPostView: View {
                 })
             }
             .sheet(isPresented: $uploadPostViewModel.isQuit) {
-                AlertModalView(uploadPostViewModel: $uploadPostViewModel)
+              AlertModalView(uploadPostViewModel: $uploadPostViewModel) {
+                router.pop()
+              }
             }
         
     }

--- a/Muje/Muje/Resource/Extension/View+.swift
+++ b/Muje/Muje/Resource/Extension/View+.swift
@@ -37,6 +37,13 @@ extension View {
         ZStack {
             self
             Toast(isShown: isShown, message: message)
+            .opacity(
+              isShown.wrappedValue ? 1 : 0
+            )
+            .animation(
+              .easeInOut(duration: 0.3),
+              value: isShown.wrappedValue
+            )
         }
     }
     


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 작업 이슈 번호를 입력해주세요
- Closes #51 


## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 작업 시 사진도 같이 올려주세요.) ]
- 병렬 로드 안에서 for문을 계속 돌아 서버 호출이 중복으로 이루어지는 현상 수정
> 초기 로드 (현재 지원자의 application, 현재 지원자가 작성한 post) 기준으로 for문을 도는게 아닌, Set을 통한 해당 데이터들의 id를 중복없이 compactMap으로 만들어주고 > 각자 패치하는 함수들(slot,thumbnail) 에서 id배열 기준으로 반복하여 로드함
> 기존 배열에 중복되어 저장되어지는것도 수정됌

- 사이클 테스트를 위한 필수적인 네비게이션은 모두 연결함. 
- 지원서 작성 or 공고 작성 후 하단 cta버튼에 나의 공고 현황탭으로 이동하는 버튼이 있는데, router.push를 통한 화면 전환을 하면 탭뷰가 뜨는게 아니라 별도의 화면이 나옴 > rootView의 tabCase를 전역에서 관리하여 popRootView() 와 tabCase == .myPostsView를 같이 걸어주어 탭전환 구현 하였음.

- 현재   private let currentUserId: String? = "0062C371-34F5-470B-BFE1-F671E23C5C97" 로 mock 유저데이터 기준 id가 들어가 있는데 실제 유저 id는 바로 위 주석처리 해놨으니 로그인 후 테스트 할 때는 변경하여 테스트

## 📋 시연 영상





